### PR TITLE
Fixing issue with file descriptors not being closed & re-opened in ap…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+tmp
+build
+log
+.project
+build.ver

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ tar: libopal marc
 .PHONY: test
 test: clean all
 	@printf "\n=== Test 1 - test1.opl - TODO ===\n"
-	build/marc input/test1.opl output/test1.opl
+	build/marc --debug --output=output/test1.opl input/test1.opl
 	diff -s test/test1.opl test/test1.opl
 	
 	@printf "\n=== Test 2 - test2.opl - TODO ===\n"
-	build/marc input/test2.opl output/test2.opl
+	build/marc --debug --output=output/test2.opl input/test2.opl
 	diff -s test/test2.opl test/test2.opl
 	
 


### PR DESCRIPTION
…propriate mode

when calling functions.

Run log with  `` make test ``

```
[Apr  4 2021 18:47:48] src/opal.c: 112         banner()
[Apr  4 2021 18:47:48] src/opal.c: 113         banner() ***************************************************************
[Apr  4 2021 18:47:48] src/opal.c: 114         banner() MARC start.
[Apr  4 2021 18:47:48] src/opal.c: 115         banner() ***************************************************************
[Apr  4 2021 18:47:48] src/opal.c: 116         banner()
[Apr  4 2021 18:47:48] src/marc.c: 127           main() Log: log/oc_log
[Apr  4 2021 18:47:48] src/marc.c: 128           main() source_fn: 'input/test2.opl'
[Apr  4 2021 18:47:48] src/marc.c: 132           main() access('input/test2.opl', F_OK) - PASS
[Apr  4 2021 18:47:48] src/marc.c: 144           main() access('input/test2.opl', R_OK) - PASS
[Apr  4 2021 18:47:48] src/marc.c: 156           main() source_fd = fopen('input/test2.opl', 'r') - PASS
[Apr  4 2021 18:47:48] src/marc.c: 170           main() dest_fn: output/test2.opl
[Apr  4 2021 18:47:48] src/marc.c: 174           main() access('output/test2.opl', F_OK) - PASS
[Apr  4 2021 18:47:48] src/marc.c: 181           main() access('output/test2.opl', W_OK) - PASS
[Apr  4 2021 18:47:48] src/marc.c: 194           main() dest_fd = fopen('output/test2.opl', 'wb') - PASS
[Apr  4 2021 18:47:48] src/marc.c: 215           main() rc_tmp: 'tmp/marc_rc.tmp'
[Apr  4 2021 18:47:48] src/marc.c: 219           main() rc_fd = fopen('tmp/marc_rc.tmp', 'wb') - PASS
[Apr  4 2021 18:47:48] src/opal.c: 239   rem_comments() Copy [source_fd] to [dest_fd] .. DONE
[Apr  4 2021 18:47:48] src/marc.c: 237           main() fclose(rc_fd) - PASS
[Apr  4 2021 18:47:48] src/marc.c: 252           main() rc_fd = fopen('tmp/marc_rc.tmp', 'r') - PASS
[Apr  4 2021 18:47:48] src/marc.c: 265           main() pi_tmp: 'tmp/marc_pi.tmp'
[Apr  4 2021 18:47:48] src/marc.c: 269           main() pi_fd = fopen('tmp/marc_pi.tmp', 'wb') - PASS
[Apr  4 2021 18:47:48] src/opal.c: 253  proc_includes() Copy [source_fd] to [dest_fd] .. DONE
[Apr  4 2021 18:47:48] src/marc.c: 291           main() fclose(rc_fd) - PASS
[Apr  4 2021 18:47:48] src/marc.c: 307           main() fclose(pi_fd) - PASS
[Apr  4 2021 18:47:48] src/marc.c: 321           main() pi_fd = fopen('tmp/marc_pi.tmp', 'r') - PASS
[Apr  4 2021 18:47:48] src/opal.c: 239   rem_comments() Copy [source_fd] to [dest_fd] .. DONE
[Apr  4 2021 18:47:48] src/marc.c: 341           main() fclose(pi_fd) - PASS
[Apr  4 2021 18:47:48] src/opal.c: 135      opal_exit() === START ===
[Apr  4 2021 18:47:48] src/opal.c: 136      opal_exit() Exit program with code: 0
[Apr  4 2021 18:47:48] src/opal.c: 140      opal_exit() fflush(stdout) - PASS
[Apr  4 2021 18:47:48] src/opal.c: 154      opal_exit() fclose(source_fd) - PASS
[Apr  4 2021 18:47:48] src/opal.c: 169      opal_exit() fflush(dest_fd) - PASS
[Apr  4 2021 18:47:48] src/opal.c: 180      opal_exit() fclose(dest_fd) - PASS
[Apr  4 2021 18:47:48] src/opal.c: 194      opal_exit() === END ===
[Apr  4 2021 18:47:48] src/opal.c: 197      opal_exit() fflush(log_fd) - PASS
[Apr  4 2021 18:47:48] src/opal.c: 208      opal_exit() fclose(log_fd)
[Apr  4 2021 18:47:48] src/opal.c: 209      opal_exit()
```