### PR TITLE
Fix memory leak issue with include files

### DIFF
--- a/src/alex.c
+++ b/src/alex.c
@@ -27,14 +27,14 @@ const char *argp_program_bug_address =
 static char doc[] = "alex - OPaL Compiler preprocessor";
 static char args_doc[] = "FILE";            ///< Arguments we accept
 static struct argp_option options[] =       ///< The options we understand
-      {
-        { "debug", 'd', 0, 0, "Log debug messages" },
-        { "log", 'l', "FILE", 0, "Save log to FILE instead of 'log/oc_log'" },
-            { "output", 'o', "FILE", 0,
-                "Output to FILE instead of standard ouput" },
-            { "report", 'r', "FILE", 0,
-                "Output report to FILE instead of 'report/oc_report.html'" },
-            { 0 } };
+  {
+    { "debug", 'd', 0, 0, "Log debug messages" },
+    { "log", 'l', "FILE", 0, "Save log to FILE instead of 'log/oc_log'" },
+    { "output", 'o', "FILE", 0, "Output to FILE instead of standard ouput" },
+    { "report", 'r', "FILE", 0,
+        "Output report to FILE instead of 'report/oc_report.html'" },
+    { 0 }
+  };
 
 struct arguments
 {
@@ -284,7 +284,10 @@ main (int argc, char **argv)
   if (source_fd)
     {
       if (fclose (source_fd) == EXIT_SUCCESS)
-        _PASS;
+        {
+          _PASS;
+          source_fd = NULL;
+        }
       else
         {
           _FAIL;
@@ -299,7 +302,10 @@ main (int argc, char **argv)
   if (rc_fd)
     {
       if (fclose (rc_fd) == EXIT_SUCCESS)
-        _PASS;
+        {
+          _PASS;
+          rc_fd = NULL;
+        }
       else
         {
           _FAIL;
@@ -352,7 +358,10 @@ main (int argc, char **argv)
       logger(DEBUG, perror_msg);
 
       if (fclose (rc_fd) == EXIT_SUCCESS)
-        _PASS;
+        {
+          _PASS;
+          rc_fd = NULL;
+        }
       else
         {
           _FAIL;
@@ -368,7 +377,10 @@ main (int argc, char **argv)
       logger(DEBUG, perror_msg);
 
       if (fclose (pi_fd) == EXIT_SUCCESS)
-        _PASS;
+        {
+          _PASS;
+          pi_fd = NULL;
+        }
       else
         {
           _FAIL;
@@ -414,7 +426,10 @@ main (int argc, char **argv)
   sprintf (perror_msg, "fclose(pi_fd)");
   logger(DEBUG, perror_msg);
   if (fclose (pi_fd) == EXIT_SUCCESS)
-    _PASS;
+    {
+      _PASS;
+      pi_fd = NULL;
+    }
   else
     {
       _FAIL;
@@ -426,7 +441,10 @@ main (int argc, char **argv)
   sprintf (perror_msg, "fclose(rc_fd)");
   logger(DEBUG, perror_msg);
   if (fclose (rc_fd) == EXIT_SUCCESS)
-    _PASS;
+    {
+      _PASS;
+      rc_fd = NULL;
+    }
   else
     {
       _FAIL;
@@ -460,11 +478,26 @@ main (int argc, char **argv)
 
   fprintf (report_fd, "\n</textarea>\n");
 
+  // Flush contents of report to disk
+  sprintf (perror_msg, "fflush(report_fd)");
+  logger(DEBUG, perror_msg);
+  if (fflush (report_fd) == EXIT_SUCCESS)
+    _PASS;
+  else
+    {
+      _FAIL;
+      perror (perror_msg);
+      return (errno);
+    }
+
   /// Close rem_comments() temp file descriptor, else print error and exit
   sprintf (perror_msg, "fclose(rc_fd)");
   logger(DEBUG, perror_msg);
   if (fclose (rc_fd) == EXIT_SUCCESS)
-    _PASS;
+    {
+      _PASS;
+      rc_fd = NULL;
+    }
   else
     {
       _FAIL;

--- a/src/opal.c
+++ b/src/opal.c
@@ -158,7 +158,10 @@ opal_exit (short code)
       sprintf (perror_msg, "fclose(source_fd)");
       logger(DEBUG, perror_msg);
       if (fclose (source_fd) == EXIT_SUCCESS)
-        _PASS;
+        {
+          _PASS;
+          source_fd = NULL;
+        }
       else
         {
           _FAIL;
@@ -191,7 +194,10 @@ opal_exit (short code)
       sprintf (perror_msg, "fclose(dest_fd)");
       logger(DEBUG, perror_msg);
       if (fclose (dest_fd) == EXIT_SUCCESS)
-        _PASS;
+        {
+          _PASS;
+          dest_fd = NULL;
+        }
       else
         {
           _FAIL;
@@ -224,7 +230,10 @@ opal_exit (short code)
       sprintf (perror_msg, "fclose(report_fd)");
       logger(DEBUG, perror_msg);
       if (fclose (report_fd) == EXIT_SUCCESS)
-        _PASS;
+        {
+          _PASS;
+          report_fd = NULL;
+        }
       else
         {
           _FAIL;
@@ -243,7 +252,7 @@ opal_exit (short code)
   /// Flush and close log file
   if (log_fd && log_fd != stdout)
     {
-      logger(DEBUG, "=== END ===");
+
 
       sprintf (perror_msg, "fflush(log_fd)");
       logger(DEBUG, perror_msg);
@@ -258,12 +267,14 @@ opal_exit (short code)
 
       sprintf (perror_msg, "fclose(log_fd)");
       logger(DEBUG, perror_msg);
+      logger(DEBUG, "=== END ===");
       logger(DEBUG, "\n");
       if (fclose (log_fd) != EXIT_SUCCESS)
         {
           perror (perror_msg);
           return (errno);
         }
+      log_fd = NULL;
     }
   else
     logger(DEBUG, "=== END ===\n\n");


### PR DESCRIPTION
Checked for file pointers being closed and mark them as NULL when no more needed.
---
Test file
```
$ cat input/alex_test1.opl 
#include "input/alex_include1.hpl"
// Single line comment

/*
Multi-line
comment
*/

-
+

// Single line comment
```
Include file
```
$ cat input/alex_include1.hpl 
// Include file comments

+
```
Run log
```
$ make clean && make && valgrind --leak-check=full --show-leak-kinds=all build/alex --debug input/alex_test1.opl
# Delete binaries
rm -fv build/* output/* tmp/*
removed 'build/alex'
removed 'build/libopal.so'
removed 'build/marc'
removed 'build/opal.o'
removed 'build/opal.tar'
removed 'tmp/marc_pi.tmp'
removed 'tmp/marc_rc.tmp'
mkdir -pv build tmp log report doc output
gcc -g -O0 -fPIC -c -Wall src/opal.c -o build/opal.o
ld -shared build/opal.o -o build/libopal.so
gcc -g -O0 -Wall -L./build -Wl,-rpath=./ src/marc.c -g -lopal -o build/marc
gcc -g -O0 -Wall -L./build -Wl,-rpath=./ src/alex.c -g -lopal -o build/alex
tar -cvf build/opal.tar build/libopal.so build/opal.o build/marc build/alex
build/libopal.so
build/opal.o
build/marc
build/alex
==90186== Memcheck, a memory error detector
==90186== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==90186== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==90186== Command: build/alex --debug input/alex_test1.opl
==90186== 
==90186== 
==90186== HEAP SUMMARY:
==90186==     in use at exit: 0 bytes in 0 blocks
==90186==   total heap usage: 27 allocs, 27 frees, 50,995 bytes allocated
==90186== 
==90186== All heap blocks were freed -- no leaks are possible
==90186== 
==90186== For lists of detected and suppressed errors, rerun with: -s
==90186== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```