### PR TITLE
Change _fd to _fp and descriptor to pointer

### DIFF
--- a/include/opal.h
+++ b/include/opal.h
@@ -33,10 +33,10 @@ char *dest_fn = NULL;           ///< Destination file name
 char *log_fn = NULL;            ///< Log file name
 char *report_fn = NULL;         ///< Report file name
 
-FILE *source_fd = NULL;         ///< Source file descriptor
-FILE *dest_fd = NULL;           ///< Destination file descriptor
-FILE *log_fd = NULL;            ///< Log file descriptor
-FILE *report_fd = NULL;         ///< Report file descriptor
+FILE *source_fp = NULL;         ///< Source file pointer
+FILE *dest_fp = NULL;           ///< Destination file pointer
+FILE *log_fp = NULL;            ///< Log file pointer
+FILE *report_fp = NULL;         ///< Report file pointer
 
 short retVal = 0;               ///< Function return value
 
@@ -164,9 +164,9 @@ lexeme_s get_identifier_lexeme (int, int);
 lexeme_s get_next_lexeme(void);
 /// Stringify lexeme
 short get_lexeme_str(lexeme_s, char*);
-/// Populate symbol table with lexemes in source file descriptor
+/// Populate symbol table with lexemes in source file pointer
 short build_symbol_table (lexeme_s*, int*);
-/// Print symbol table to destination file descriptor
+/// Print symbol table to destination file pointer
 short print_symbol_table (lexeme_s*, FILE*);
 
 #endif /* OPAL_H_ */

--- a/src/alex.c
+++ b/src/alex.c
@@ -127,9 +127,9 @@ main (int argc, char **argv)
           strdup (arguments.report) : strdup ("report/oc_report.html");
 
   /// Open log file in append mode, else exit program
-  sprintf (perror_msg, "log_fd = fopen(%s, 'a')", log_fn);
-  log_fd = fopen (log_fn, "a");
-  if (log_fd == NULL)
+  sprintf (perror_msg, "log_fp = fopen(%s, 'a')", log_fn);
+  log_fp = fopen (log_fn, "a");
+  if (log_fp == NULL)
     {
       _FAIL;
       perror (perror_msg);
@@ -191,10 +191,10 @@ main (int argc, char **argv)
         }
 
       /// Open destination file in 'wb' mode
-      sprintf (perror_msg, "dest_fd = fopen('%s', 'wb')", dest_fn);
+      sprintf (perror_msg, "dest_fp = fopen('%s', 'wb')", dest_fn);
       logger(DEBUG, perror_msg);
-      dest_fd = fopen (dest_fn, "wb");
-      if (dest_fd)
+      dest_fp = fopen (dest_fn, "wb");
+      if (dest_fp)
         _PASS;
       else
         {
@@ -207,14 +207,14 @@ main (int argc, char **argv)
   else
     {
       logger(DEBUG, "Destination: STDOUT");
-      dest_fd = stdout;
+      dest_fp = stdout;
     }
 
   /// Open source file in read-only mode
-  sprintf (perror_msg, "source_fd = fopen('%s', 'r')", source_fn);
+  sprintf (perror_msg, "source_fp = fopen('%s', 'r')", source_fn);
   logger(DEBUG, perror_msg);
-  source_fd = fopen (source_fn, "r");
-  if (source_fd != NULL)
+  source_fp = fopen (source_fn, "r");
+  if (source_fp != NULL)
     _PASS;
   else
     {
@@ -236,10 +236,10 @@ main (int argc, char **argv)
     }
 
   /// If report file can not be written, print error and exit
-  sprintf (perror_msg, "report_fd = fopen('%s', 'a')", report_fn);
+  sprintf (perror_msg, "report_fp = fopen('%s', 'a')", report_fn);
   logger(DEBUG, perror_msg);
-  report_fd = fopen (report_fn, "a");
-  if (report_fd != NULL)
+  report_fp = fopen (report_fn, "a");
+  if (report_fp != NULL)
     _PASS;
   else
     {
@@ -249,7 +249,7 @@ main (int argc, char **argv)
     }
 
   /// Initialize HTML report file
-  retVal = init_report(report_fd);
+  retVal = init_report(report_fp);
   if (retVal != EXIT_SUCCESS)
     opal_exit(retVal);
 
@@ -261,10 +261,10 @@ main (int argc, char **argv)
   logger(DEBUG, "rc_tmp: '%s'", rc_tmp);
 
   /// If temp file can not be written, print error and exit
-  sprintf (perror_msg, "rc_fd = fopen('%s', 'wb')", rc_tmp);
+  sprintf (perror_msg, "rc_fp = fopen('%s', 'wb')", rc_tmp);
   logger(DEBUG, perror_msg);
-  FILE *rc_fd = fopen (rc_tmp, "wb");
-  if (rc_fd != NULL)
+  FILE *rc_fp = fopen (rc_tmp, "wb");
+  if (rc_fp != NULL)
     _PASS;
   else
     {
@@ -274,19 +274,19 @@ main (int argc, char **argv)
     }
 
   /// Remove comments from source with rem_comments(), write to rc_tmp
-  retVal = rem_comments (source_fd, rc_fd);
+  retVal = rem_comments (source_fp, rc_fp);
   if (retVal != EXIT_SUCCESS)
     return (opal_exit (retVal));
 
-  /// Close source file descriptor source_fd if not NULL
-  sprintf (perror_msg, "fclose(source_fd)");
+  /// Close source file pointer source_fp if not NULL
+  sprintf (perror_msg, "fclose(source_fp)");
   logger(DEBUG, perror_msg);
-  if (source_fd)
+  if (source_fp)
     {
-      if (fclose (source_fd) == EXIT_SUCCESS)
+      if (fclose (source_fp) == EXIT_SUCCESS)
         {
           _PASS;
-          source_fd = NULL;
+          source_fp = NULL;
         }
       else
         {
@@ -296,15 +296,15 @@ main (int argc, char **argv)
         }
     }
 
-  /// Close rem_comments() temp file descriptor rc_fd if not NULL
-  sprintf (perror_msg, "fclose(rc_fd)");
+  /// Close rem_comments() temp file pointer rc_fp if not NULL
+  sprintf (perror_msg, "fclose(rc_fp)");
   logger(DEBUG, perror_msg);
-  if (rc_fd)
+  if (rc_fp)
     {
-      if (fclose (rc_fd) == EXIT_SUCCESS)
+      if (fclose (rc_fp) == EXIT_SUCCESS)
         {
           _PASS;
-          rc_fd = NULL;
+          rc_fp = NULL;
         }
       else
         {
@@ -315,10 +315,10 @@ main (int argc, char **argv)
     }
 
   /// Open rem_comments() temp file in read mode, else print error and exit
-  sprintf (perror_msg, "rc_fd = fopen('%s', 'r')", rc_tmp);
+  sprintf (perror_msg, "rc_fp = fopen('%s', 'r')", rc_tmp);
   logger(DEBUG, perror_msg);
-  rc_fd = fopen (rc_tmp, "r");
-  if (rc_fd != NULL)
+  rc_fp = fopen (rc_tmp, "r");
+  if (rc_fp != NULL)
     _PASS;
   else
     {
@@ -332,10 +332,10 @@ main (int argc, char **argv)
   logger(DEBUG, "pi_tmp: '%s'", pi_tmp);
 
   /// If temp file can not be written, print error and exit
-  sprintf (perror_msg, "pi_fd = fopen('%s', 'wb')", pi_tmp);
+  sprintf (perror_msg, "pi_fp = fopen('%s', 'wb')", pi_tmp);
   logger(DEBUG, perror_msg);
-  FILE *pi_fd = fopen (pi_tmp, "wb");
-  if (pi_fd != NULL)
+  FILE *pi_fp = fopen (pi_tmp, "wb");
+  if (pi_fp != NULL)
     _PASS;
   else
     {
@@ -345,22 +345,22 @@ main (int argc, char **argv)
     }
 
   /// Process #include directives from source with proc_includes()
-  retVal = proc_includes (rc_fd, pi_fd);
+  retVal = proc_includes (rc_fp, pi_fp);
   if (retVal != EXIT_SUCCESS)
     {
       return (opal_exit (retVal));
     }
 
-  /// Close rem_comments temp file descriptor if not NULL
-  if (rc_fd)
+  /// Close rem_comments temp file pointer if not NULL
+  if (rc_fp)
     {
-      sprintf (perror_msg, "fclose(rc_fd)");
+      sprintf (perror_msg, "fclose(rc_fp)");
       logger(DEBUG, perror_msg);
 
-      if (fclose (rc_fd) == EXIT_SUCCESS)
+      if (fclose (rc_fp) == EXIT_SUCCESS)
         {
           _PASS;
-          rc_fd = NULL;
+          rc_fp = NULL;
         }
       else
         {
@@ -370,16 +370,16 @@ main (int argc, char **argv)
         }
     }
 
-  /// Close proc_includes() temp file descriptor if not NULL
-  if (pi_fd)
+  /// Close proc_includes() temp file pointer if not NULL
+  if (pi_fp)
     {
-      sprintf (perror_msg, "fclose(pi_fd)");
+      sprintf (perror_msg, "fclose(pi_fp)");
       logger(DEBUG, perror_msg);
 
-      if (fclose (pi_fd) == EXIT_SUCCESS)
+      if (fclose (pi_fp) == EXIT_SUCCESS)
         {
           _PASS;
-          pi_fd = NULL;
+          pi_fp = NULL;
         }
       else
         {
@@ -390,10 +390,10 @@ main (int argc, char **argv)
     }
 
   /// Open proc_includes() temp file in read mode, else print error and exit
-  sprintf (perror_msg, "pi_fd = fopen('%s', 'r')", pi_tmp);
+  sprintf (perror_msg, "pi_fp = fopen('%s', 'r')", pi_tmp);
   logger(DEBUG, perror_msg);
-  pi_fd = fopen (pi_tmp, "r");
-  if (pi_fd != NULL)
+  pi_fp = fopen (pi_tmp, "r");
+  if (pi_fp != NULL)
     _PASS;
   else
     {
@@ -403,10 +403,10 @@ main (int argc, char **argv)
     }
 
   /// Open rem_comments() temp file in write mode, else print error and exit
-  sprintf (perror_msg, "rc_fd = fopen('%s', 'wb')", rc_tmp);
+  sprintf (perror_msg, "rc_fp = fopen('%s', 'wb')", rc_tmp);
   logger(DEBUG, perror_msg);
-  rc_fd = fopen (rc_tmp, "wb");
-  if (rc_fd != NULL)
+  rc_fp = fopen (rc_tmp, "wb");
+  if (rc_fp != NULL)
     _PASS;
   else
     {
@@ -416,19 +416,19 @@ main (int argc, char **argv)
     }
 
   /// Remove comments from includs files with rem_comments(), write to rc_tmp
-  retVal = rem_comments (pi_fd, rc_fd);
+  retVal = rem_comments (pi_fp, rc_fp);
   if (retVal != EXIT_SUCCESS)
     {
       return (opal_exit (retVal));
     }
 
-  /// Close proc_includes() temp file descriptor, else print error and exit
-  sprintf (perror_msg, "fclose(pi_fd)");
+  /// Close proc_includes() temp file pointer, else print error and exit
+  sprintf (perror_msg, "fclose(pi_fp)");
   logger(DEBUG, perror_msg);
-  if (fclose (pi_fd) == EXIT_SUCCESS)
+  if (fclose (pi_fp) == EXIT_SUCCESS)
     {
       _PASS;
-      pi_fd = NULL;
+      pi_fp = NULL;
     }
   else
     {
@@ -437,13 +437,13 @@ main (int argc, char **argv)
       return (errno);
     }
 
-  /// Close rem_comments() temp file descriptor, else print error and exit
-  sprintf (perror_msg, "fclose(rc_fd)");
+  /// Close rem_comments() temp file pointer, else print error and exit
+  sprintf (perror_msg, "fclose(rc_fp)");
   logger(DEBUG, perror_msg);
-  if (fclose (rc_fd) == EXIT_SUCCESS)
+  if (fclose (rc_fp) == EXIT_SUCCESS)
     {
       _PASS;
-      rc_fd = NULL;
+      rc_fp = NULL;
     }
   else
     {
@@ -453,10 +453,10 @@ main (int argc, char **argv)
     }
 
   /// Open rem_comments() temp file in read mode, else print error and exit
-  sprintf (perror_msg, "rc_fd = fopen('%s', 'r')", rc_tmp);
+  sprintf (perror_msg, "rc_fp = fopen('%s', 'r')", rc_tmp);
   logger(DEBUG, perror_msg);
-  rc_fd = fopen (rc_tmp, "r");
-  if (rc_fd != NULL)
+  rc_fp = fopen (rc_tmp, "r");
+  if (rc_fp != NULL)
     _PASS;
   else
     {
@@ -466,22 +466,22 @@ main (int argc, char **argv)
     }
 
   /// Open textarea tag in report file for MARC output
-  fprintf (report_fd, "<h3>MARC output: </h3>\n<hr>\n"
+  fprintf (report_fp, "<h3>MARC output: </h3>\n<hr>\n"
            "<textarea style='resize: none;' readonly rows='25' cols='80'>\n");
 
   /// Append MARC output file to report file
   char ch = 0;
   logger (DEBUG, "Copying MARC output to HTML report");
-  while ((ch = fgetc (rc_fd)) != EOF)
-    fputc (ch, report_fd);
+  while ((ch = fgetc (rc_fp)) != EOF)
+    fputc (ch, report_fp);
   _DONE;
 
-  fprintf (report_fd, "\n</textarea>\n");
+  fprintf (report_fp, "\n</textarea>\n");
 
   // Flush contents of report to disk
-  sprintf (perror_msg, "fflush(report_fd)");
+  sprintf (perror_msg, "fflush(report_fp)");
   logger(DEBUG, perror_msg);
-  if (fflush (report_fd) == EXIT_SUCCESS)
+  if (fflush (report_fp) == EXIT_SUCCESS)
     _PASS;
   else
     {
@@ -490,13 +490,13 @@ main (int argc, char **argv)
       return (errno);
     }
 
-  /// Close rem_comments() temp file descriptor, else print error and exit
-  sprintf (perror_msg, "fclose(rc_fd)");
+  /// Close rem_comments() temp file pointer, else print error and exit
+  sprintf (perror_msg, "fclose(rc_fp)");
   logger(DEBUG, perror_msg);
-  if (fclose (rc_fd) == EXIT_SUCCESS)
+  if (fclose (rc_fp) == EXIT_SUCCESS)
     {
       _PASS;
-      rc_fd = NULL;
+      rc_fp = NULL;
     }
   else
     {
@@ -508,11 +508,11 @@ main (int argc, char **argv)
   /// Start lexical analyzer code
   banner ("ALEX start.");
 
-  /// Open rem_comments() temp file as source_fd, else print error and exit
-  sprintf (perror_msg, "source_fd = fopen('%s', 'r')", rc_tmp);
+  /// Open rem_comments() temp file as source_fp, else print error and exit
+  sprintf (perror_msg, "source_fp = fopen('%s', 'r')", rc_tmp);
   logger(DEBUG, perror_msg);
-  source_fd = fopen (rc_tmp, "r");
-  if (source_fd != NULL)
+  source_fp = fopen (rc_tmp, "r");
+  if (source_fp != NULL)
     _PASS;
   else
     {
@@ -539,7 +539,7 @@ main (int argc, char **argv)
   _PASS;
 
   /// Print symbol table with print_symbol_table() to destination
-  retVal = print_symbol_table (symbol_table, dest_fd);
+  retVal = print_symbol_table (symbol_table, dest_fp);
   if (retVal != EXIT_SUCCESS)
     {
       return (opal_exit (retVal));
@@ -550,7 +550,7 @@ main (int argc, char **argv)
   free (symbol_table);
   symbol_table = NULL;
 
-  /// source_fd, dest_fd, log_fd & report_fd closed by opal_exit()
+  /// source_fp, dest_fp, log_fp & report_fp closed by opal_exit()
   return (opal_exit (EXIT_SUCCESS));
 }
 

--- a/src/marc.c
+++ b/src/marc.c
@@ -117,9 +117,9 @@ main (int argc, char **argv)
       arguments.logfile ? strdup (arguments.logfile) : strdup ("log/oc_log");
 
   /// Open log file in append mode, else exit program
-  sprintf (perror_msg, "log_fd = fopen(%s, 'a')", log_fn);
-  log_fd = fopen (log_fn, "a");
-  if (log_fd == NULL)
+  sprintf (perror_msg, "log_fp = fopen(%s, 'a')", log_fn);
+  log_fp = fopen (log_fn, "a");
+  if (log_fp == NULL)
     {
       _FAIL;
       perror (perror_msg);
@@ -155,10 +155,10 @@ main (int argc, char **argv)
     }
 
   /// Open source file in read-only mode
-  sprintf (perror_msg, "source_fd = fopen('%s', 'r')", source_fn);
+  sprintf (perror_msg, "source_fp = fopen('%s', 'r')", source_fn);
   logger (DEBUG, perror_msg);
-  source_fd = fopen (source_fn, "r");
-  if (source_fd != NULL)
+  source_fp = fopen (source_fn, "r");
+  if (source_fp != NULL)
     _PASS;
   else
     {
@@ -193,10 +193,10 @@ main (int argc, char **argv)
         }
 
       /// Open destination file in 'wb' mode
-      sprintf (perror_msg, "dest_fd = fopen('%s', 'wb')", dest_fn);
+      sprintf (perror_msg, "dest_fp = fopen('%s', 'wb')", dest_fn);
       logger (DEBUG, perror_msg);
-      dest_fd = fopen (dest_fn, "wb");
-      if (dest_fd)
+      dest_fp = fopen (dest_fn, "wb");
+      if (dest_fp)
         _PASS;
       else
         {
@@ -209,7 +209,7 @@ main (int argc, char **argv)
   else
     {
       logger (DEBUG, "Destination: STDOUT");
-      dest_fd = stdout;
+      dest_fp = stdout;
     }
 
   /// Create and open temp destination file for remove_comments()
@@ -217,10 +217,10 @@ main (int argc, char **argv)
   logger (DEBUG, "rc_tmp: '%s'", rc_tmp);
 
   /// If temp file can not be written, print error and exit
-  sprintf (perror_msg, "rc_fd = fopen('%s', 'wb')", rc_tmp);
+  sprintf (perror_msg, "rc_fp = fopen('%s', 'wb')", rc_tmp);
   logger (DEBUG, perror_msg);
-  FILE *rc_fd = fopen (rc_tmp, "wb");
-  if (rc_fd != NULL)
+  FILE *rc_fp = fopen (rc_tmp, "wb");
+  if (rc_fp != NULL)
     _PASS;
   else
     {
@@ -230,16 +230,16 @@ main (int argc, char **argv)
     }
 
   /// Remove comments from source with rem_comments(), write to rc_tmp
-  retVal = rem_comments (source_fd, rc_fd);
+  retVal = rem_comments (source_fp, rc_fp);
   if (retVal != EXIT_SUCCESS)
       return (opal_exit (retVal));
 
-  /// Close rem_comments temp file descriptor rc_fd if not NULL
-  sprintf (perror_msg, "fclose(rc_fd)");
+  /// Close rem_comments temp file pointer rc_fp if not NULL
+  sprintf (perror_msg, "fclose(rc_fp)");
   logger (DEBUG, perror_msg);
-  if (rc_fd)
+  if (rc_fp)
     {
-      if (fclose (rc_fd) == EXIT_SUCCESS)
+      if (fclose (rc_fp) == EXIT_SUCCESS)
         _PASS;
       else
         {
@@ -250,10 +250,10 @@ main (int argc, char **argv)
     }
 
   /// Open rem_comments temp file in read mode, else print error and exit
-  sprintf (perror_msg, "rc_fd = fopen('%s', 'r')", rc_tmp);
+  sprintf (perror_msg, "rc_fp = fopen('%s', 'r')", rc_tmp);
   logger (DEBUG, perror_msg);
-  rc_fd = fopen (rc_tmp, "r");
-  if (rc_fd != NULL)
+  rc_fp = fopen (rc_tmp, "r");
+  if (rc_fp != NULL)
     _PASS;
   else
     {
@@ -267,10 +267,10 @@ main (int argc, char **argv)
   logger (DEBUG, "pi_tmp: '%s'", pi_tmp);
 
   /// If temp file can not be written, print error and exit
-  sprintf (perror_msg, "pi_fd = fopen('%s', 'wb')", pi_tmp);
+  sprintf (perror_msg, "pi_fp = fopen('%s', 'wb')", pi_tmp);
   logger (DEBUG, perror_msg);
-  FILE *pi_fd = fopen (pi_tmp, "wb");
-  if (pi_fd != NULL)
+  FILE *pi_fp = fopen (pi_tmp, "wb");
+  if (pi_fp != NULL)
     _PASS;
   else
     {
@@ -280,19 +280,19 @@ main (int argc, char **argv)
     }
 
   /// Process #include directives from source with proc_includes()
-  retVal = proc_includes (rc_fd, pi_fd);
+  retVal = proc_includes (rc_fp, pi_fp);
   if (retVal != EXIT_SUCCESS)
     {
       return (opal_exit (retVal));
     }
 
-  /// Close rem_comments temp file descriptor if not NULL
-  if (rc_fd)
+  /// Close rem_comments temp file pointer if not NULL
+  if (rc_fp)
     {
-      sprintf (perror_msg, "fclose(rc_fd)");
+      sprintf (perror_msg, "fclose(rc_fp)");
       logger (DEBUG, perror_msg);
 
-      if (fclose (rc_fd) == EXIT_SUCCESS)
+      if (fclose (rc_fp) == EXIT_SUCCESS)
         _PASS;
       else
         {
@@ -302,13 +302,13 @@ main (int argc, char **argv)
         }
     }
 
-  /// Close proc_includes temp file descriptor if not NULL
-  if (pi_fd)
+  /// Close proc_includes temp file pointer if not NULL
+  if (pi_fp)
     {
-      sprintf (perror_msg, "fclose(pi_fd)");
+      sprintf (perror_msg, "fclose(pi_fp)");
       logger (DEBUG, perror_msg);
 
-      if (fclose (pi_fd) == EXIT_SUCCESS)
+      if (fclose (pi_fp) == EXIT_SUCCESS)
         _PASS;
       else
         {
@@ -319,10 +319,10 @@ main (int argc, char **argv)
     }
 
   /// Open proc_includes temp file in read mode, else print error and exit
-  sprintf (perror_msg, "pi_fd = fopen('%s', 'r')", pi_tmp);
+  sprintf (perror_msg, "pi_fp = fopen('%s', 'r')", pi_tmp);
   logger (DEBUG, perror_msg);
-  pi_fd = fopen (pi_tmp, "r");
-  if (pi_fd != NULL)
+  pi_fp = fopen (pi_tmp, "r");
+  if (pi_fp != NULL)
     _PASS;
   else
     {
@@ -332,16 +332,16 @@ main (int argc, char **argv)
     }
 
   /// Remove comments included file with rem_comments(), write to destination
-  retVal = rem_comments (pi_fd, dest_fd);
+  retVal = rem_comments (pi_fp, dest_fp);
   if (retVal != EXIT_SUCCESS)
     {
       return (opal_exit (retVal));
     }
 
-  /// Close proc_includes temp file descriptor
-  sprintf (perror_msg, "fclose(pi_fd)");
+  /// Close proc_includes temp file pointer
+  sprintf (perror_msg, "fclose(pi_fp)");
   logger (DEBUG, perror_msg);
-  if (fclose (pi_fd) == EXIT_SUCCESS)
+  if (fclose (pi_fp) == EXIT_SUCCESS)
     _PASS;
   else
     {
@@ -350,7 +350,7 @@ main (int argc, char **argv)
       return (errno);
     }
 
-  /// source_fd and dest_fd closed by opal_exit()
+  /// source_fp and dest_fp closed by opal_exit()
   return (opal_exit (EXIT_SUCCESS));
 }
 

--- a/src/opal.c
+++ b/src/opal.c
@@ -23,7 +23,7 @@
  * @brief       Print formatted message to log file
  *
  * @details     Helper function to log messages. Function writes to global
- * variable log_fd. Usually called by a macro logger. Eg:
+ * variable log_fp. Usually called by a macro logger. Eg:
  *
  * ```
  * logger (ERROR, "Cannot read file: %s", file_name);
@@ -45,8 +45,8 @@ opal_log (log_level_e tag, const char *file, int line, const char *func,
           const char *fmt, ...)
 {
 
-  /// 1. Assert log file descriptor is not null
-  assert(log_fd);
+  /// 1. Assert log file pointer is not null
+  assert(log_fp);
 
   /// 2. Allocate buffer to hold message to log
   char buf[1024] =
@@ -64,26 +64,26 @@ opal_log (log_level_e tag, const char *file, int line, const char *func,
    */
   if (tag == RESULT && LOG_LEVEL >= DEBUG)
     {
-      fprintf (log_fd, "%s", buf);
-      fflush (log_fd);
+      fprintf (log_fp, "%s", buf);
+      fflush (log_fp);
       return;
     }
 
   /**
    * 5. If log message is less than current log level, print message with
-   * current date, time to log file descriptor. Eg.
+   * current date, time to log file pointer. Eg.
    *
    * ```
-   * [05/02/2021 20:57:58] [DEBUG]   main() [source_fd] access('input/hello.opl', R_OK) - PASS
+   * [05/02/2021 20:57:58] [DEBUG]   main() [source_fp] access('input/hello.opl', R_OK) - PASS
    * ```
    */
   if (tag <= LOG_LEVEL)
     {
-      fprintf (log_fd, "\n[%10s:%4d] %20s() %s", file, line, func, buf);
+      fprintf (log_fp, "\n[%10s:%4d] %20s() %s", file, line, func, buf);
     }
 
   /// 6. Flush message to log file
-  fflush (log_fd);
+  fflush (log_fp);
 }
 
 /**
@@ -153,14 +153,14 @@ opal_exit (short code)
     }
 
   /// Close source file
-  if (source_fd && source_fd != stdin)
+  if (source_fp && source_fp != stdin)
     {
-      sprintf (perror_msg, "fclose(source_fd)");
+      sprintf (perror_msg, "fclose(source_fp)");
       logger(DEBUG, perror_msg);
-      if (fclose (source_fd) == EXIT_SUCCESS)
+      if (fclose (source_fp) == EXIT_SUCCESS)
         {
           _PASS;
-          source_fd = NULL;
+          source_fp = NULL;
         }
       else
         {
@@ -178,11 +178,11 @@ opal_exit (short code)
     }
 
   /// Flush and close destination file
-  if (dest_fd && dest_fd != stdout)
+  if (dest_fp && dest_fp != stdout)
     {
-      sprintf (perror_msg, "fflush(dest_fd)");
+      sprintf (perror_msg, "fflush(dest_fp)");
       logger(DEBUG, perror_msg);
-      if (fflush (dest_fd) == EXIT_SUCCESS)
+      if (fflush (dest_fp) == EXIT_SUCCESS)
         _PASS;
       else
         {
@@ -191,12 +191,12 @@ opal_exit (short code)
           return (errno);
         }
 
-      sprintf (perror_msg, "fclose(dest_fd)");
+      sprintf (perror_msg, "fclose(dest_fp)");
       logger(DEBUG, perror_msg);
-      if (fclose (dest_fd) == EXIT_SUCCESS)
+      if (fclose (dest_fp) == EXIT_SUCCESS)
         {
           _PASS;
-          dest_fd = NULL;
+          dest_fp = NULL;
         }
       else
         {
@@ -214,11 +214,11 @@ opal_exit (short code)
     }
 
   /// Flush and close report file
-  if (report_fd)
+  if (report_fp)
     {
-      sprintf (perror_msg, "fflush(report_fd)");
+      sprintf (perror_msg, "fflush(report_fp)");
       logger(DEBUG, perror_msg);
-      if (fflush (report_fd) == EXIT_SUCCESS)
+      if (fflush (report_fp) == EXIT_SUCCESS)
         _PASS;
       else
         {
@@ -227,12 +227,12 @@ opal_exit (short code)
           return (errno);
         }
 
-      sprintf (perror_msg, "fclose(report_fd)");
+      sprintf (perror_msg, "fclose(report_fp)");
       logger(DEBUG, perror_msg);
-      if (fclose (report_fd) == EXIT_SUCCESS)
+      if (fclose (report_fp) == EXIT_SUCCESS)
         {
           _PASS;
-          report_fd = NULL;
+          report_fp = NULL;
         }
       else
         {
@@ -250,13 +250,13 @@ opal_exit (short code)
     }
 
   /// Flush and close log file
-  if (log_fd && log_fd != stdout)
+  if (log_fp && log_fp != stdout)
     {
 
 
-      sprintf (perror_msg, "fflush(log_fd)");
+      sprintf (perror_msg, "fflush(log_fp)");
       logger(DEBUG, perror_msg);
-      if (fflush (log_fd) == EXIT_SUCCESS)
+      if (fflush (log_fp) == EXIT_SUCCESS)
         _PASS;
       else
         {
@@ -265,16 +265,16 @@ opal_exit (short code)
           return (errno);
         }
 
-      sprintf (perror_msg, "fclose(log_fd)");
+      sprintf (perror_msg, "fclose(log_fp)");
       logger(DEBUG, perror_msg);
       logger(DEBUG, "=== END ===");
       logger(DEBUG, "\n");
-      if (fclose (log_fd) != EXIT_SUCCESS)
+      if (fclose (log_fp) != EXIT_SUCCESS)
         {
           perror (perror_msg);
           return (errno);
         }
-      log_fd = NULL;
+      log_fp = NULL;
     }
   else
     logger(DEBUG, "=== END ===\n\n");
@@ -289,11 +289,11 @@ opal_exit (short code)
 }
 
 /**
- * @brief       Function to read next character from the source file descriptor
+ * @brief       Function to read next character from the source file pointer
  *
  * @return      Character read
  *
- * @retval      Next character read from FILE *stream source_fd
+ * @retval      Next character read from FILE *stream source_fp
  * @retval      errno           On system call failure
  *
  */
@@ -301,8 +301,8 @@ opal_exit (short code)
 int
 read_next_char (void)
 {
-  /// Read character from source file descriptor
-  next_char = getc (source_fd);
+  /// Read character from source file pointer
+  next_char = getc (source_fp);
 
   /// getc() sets the errno in the event of an error
   if (errno != 0)
@@ -328,7 +328,7 @@ read_next_char (void)
 /**
  * @brief   Initialize HTML report file
  *
- * @param[int/out] report_fd    Report file descriptor
+ * @param[int/out] report_fp    Report file pointer
  *
  * @return      The error return code of the function.
  *
@@ -339,17 +339,17 @@ read_next_char (void)
  */
 
 short
-init_report (FILE *report_fd)
+init_report (FILE *report_fp)
 {
 
   logger(DEBUG, "=== START ===");
 
-  /// Assert report file descriptor is not NULL
-  assert(report_fd);
+  /// Assert report file pointer is not NULL
+  assert(report_fp);
 
   /// Write HTML head tag to the report
   logger (DEBUG, "Writing HTML head tag to report");
-  fprintf (report_fd, "<!DOCTYPE html>\n"
+  fprintf (report_fp, "<!DOCTYPE html>\n"
            "<html>\n"
            "<head>\n"
            "<title>OPaL compilation report</title>\n"
@@ -358,10 +358,10 @@ init_report (FILE *report_fd)
            "</head>\n");
 
   /// Start HTML body tag
-  fprintf (report_fd, "<body>\n");
+  fprintf (report_fp, "<body>\n");
 
   /// Open textarea tag for source file
-  fprintf (report_fd, "<h2>Compilation steps report </h2>\n"
+  fprintf (report_fp, "<h2>Compilation steps report </h2>\n"
            "<h3>Original source file: <code>%s</code></h3>\n<hr>\n"
            "<textarea style='resize: none;' readonly rows='25' cols='80'>\n",
            source_fn);
@@ -369,20 +369,20 @@ init_report (FILE *report_fd)
   /// Append source file to HTML report and close textarea tag
   char ch = 0;
   logger (DEBUG, "Copying source file to HTML report");
-  while ((ch = fgetc (source_fd)) != EOF)
-    fputc (ch, report_fd);
+  while ((ch = fgetc (source_fp)) != EOF)
+    fputc (ch, report_fp);
   _DONE;
 
-  fprintf (report_fd, "\n</textarea>\n");
-  fflush (report_fd);
+  fprintf (report_fp, "\n</textarea>\n");
+  fflush (report_fp);
 
-  /// Rewind source file descriptor
+  /// Rewind source file pointer
   sprintf (perror_msg, "rewind('%s')", source_fn);
   logger(DEBUG, perror_msg);
-  rewind (source_fd);
+  rewind (source_fp);
 
   /// If current value of source file position not 0, print error and exit
-  if (ftell (source_fd) == 0)
+  if (ftell (source_fp) == 0)
     {
       _DONE;
     }
@@ -412,8 +412,8 @@ init_report (FILE *report_fd)
 /**
  * @brief       Function to read from source, remove comments, and write to destination
  *
- * @param[in]   source_fd     Source to be read from
- * @param[in]   dest_fd       Destination to written to
+ * @param[in]   source_fp     Source to be read from
+ * @param[in]   dest_fp       Destination to written to
  *
  * @return      The error return code of the function.
  *
@@ -424,18 +424,18 @@ init_report (FILE *report_fd)
  */
 
 short
-rem_comments (FILE *source_fd, FILE *dest_fd)
+rem_comments (FILE *source_fp, FILE *dest_fp)
 {
   logger(DEBUG, "=== START ===");
 
-  /// Check if source file descriptor is not NULL
-  logger(DEBUG, "assert(source_fd)");
-  assert(source_fd);
+  /// Check if source file pointer is not NULL
+  logger(DEBUG, "assert(source_fp)");
+  assert(source_fp);
   _PASS;
 
-  /// Check if destination file descriptor is not NULL
-  logger(DEBUG, "assert(dest_fd)");
-  assert(dest_fd);
+  /// Check if destination file pointer is not NULL
+  logger(DEBUG, "assert(dest_fp)");
+  assert(dest_fp);
   _PASS;
 
   char ch = 0;
@@ -444,17 +444,17 @@ rem_comments (FILE *source_fd, FILE *dest_fd)
   int numComments = 0;
 
   /// Start reading characters from file
-  while ((ch = fgetc (source_fd)) != EOF)
+  while ((ch = fgetc (source_fp)) != EOF)
     {
       /// If character is not a /, line is not a comment
       if (ch != '/')
         {
-          fputc (ch, dest_fd);
+          fputc (ch, dest_fp);
           continue;
         }
       /// If character is a /, read next character
       else
-        charNext = fgetc (source_fd);
+        charNext = fgetc (source_fp);
 
       /// If next character is / or *, line is a comment, set flag
       if (charNext == '/' || charNext == '*')
@@ -465,15 +465,15 @@ rem_comments (FILE *source_fd, FILE *dest_fd)
       /// else, not a comment, write both characters to file
       else
         {
-          fputc (ch, dest_fd);
-          fputc (charNext, dest_fd);
+          fputc (ch, dest_fp);
+          fputc (charNext, dest_fp);
         }
 
       /// If comment flag is set, process comment
       while (isComment)
         {
           /// Read next character from file
-          ch = fgetc (source_fd);
+          ch = fgetc (source_fp);
 
           /// If next character is /, process single line comment
           if (charNext == '/' && (ch == '\n' || ch == EOF))
@@ -487,7 +487,7 @@ rem_comments (FILE *source_fd, FILE *dest_fd)
           /// If next character is *, process multi-line comment
           if (charNext == '*' && ch == '*')
             {
-              ch = fgetc (source_fd);
+              ch = fgetc (source_fp);
               if (ch == '\n')
                 numComments++;
 
@@ -509,7 +509,7 @@ rem_comments (FILE *source_fd, FILE *dest_fd)
           /// If char is a newline, write to file to preserve line numbers
           if (ch == '\n')
             {
-              fputc (ch, dest_fd);
+              fputc (ch, dest_fp);
             }
         }
     }
@@ -522,8 +522,8 @@ rem_comments (FILE *source_fd, FILE *dest_fd)
 /**
  * @brief       Read source, process includes, write to destination
  *
- * @param[in]   source_fd     Source to be read from
- * @param[in]   dest_fd       Destination to written to
+ * @param[in]   source_fp     Source to be read from
+ * @param[in]   dest_fp       Destination to written to
  *
  * @return      The error return code of the function.
  *
@@ -534,26 +534,26 @@ rem_comments (FILE *source_fd, FILE *dest_fd)
  */
 
 short
-proc_includes (FILE *source_fd, FILE *dest_fd)
+proc_includes (FILE *source_fp, FILE *dest_fp)
 {
   logger(DEBUG, "=== START ===");
 
-  /// Assert source file descriptor is not NULL
-  logger(DEBUG, "assert(source_fd)");
-  assert(source_fd);
+  /// Assert source file pointer is not NULL
+  logger(DEBUG, "assert(source_fp)");
+  assert(source_fp);
   _PASS;
 
-  /// Assert destination file descriptor is not NULL
-  logger(DEBUG, "assert(dest_fd)");
-  assert(dest_fd);
+  /// Assert destination file pointer is not NULL
+  logger(DEBUG, "assert(dest_fp)");
+  assert(dest_fp);
   _PASS;
 
-  /// Move source_fd to beginning of file.
-  fseek (source_fd, 0, SEEK_SET);
+  /// Move source_fp to beginning of file.
+  fseek (source_fp, 0, SEEK_SET);
 
   /// Copy each character to the destination file, while checking for include files.
   logger(DEBUG, "Reading file.");
-  char ch = fgetc (source_fd);
+  char ch = fgetc (source_fp);
   while (ch != EOF)
     {
       switch (ch)
@@ -571,10 +571,10 @@ proc_includes (FILE *source_fd, FILE *dest_fd)
             char include_buffer[9] =
               { 0 };
             ssize_t sz = fread (include_buffer, sizeof(char), sizeof(char) * 8,
-                                source_fd);
+                                source_fp);
 
             /// Rewinds the file pointer.
-            fseek (source_fd, -sz, SEEK_CUR);
+            fseek (source_fp, -sz, SEEK_CUR);
 
             /// If include is found, process the included file.
             if (strcasecmp (include_buffer, "include ") == 0)
@@ -582,18 +582,18 @@ proc_includes (FILE *source_fd, FILE *dest_fd)
                 logger(DEBUG, "Include keyword has been found.");
 
                 /// Move file pointer to the point after "include "
-                fseek (source_fd, sz, SEEK_CUR);
+                fseek (source_fp, sz, SEEK_CUR);
                 char filename_buffer[256] =
                   { 0 };
                 int filename_len = 0;
 
                 /// Get the filename for the include file.
-                ch = fgetc (source_fd);
+                ch = fgetc (source_fp);
                 while (ch != '\n' && filename_len < 256)
                   {
                     if (ch != '"')
                       filename_buffer[filename_len++] = ch;
-                    ch = fgetc (source_fd);
+                    ch = fgetc (source_fp);
                   }
                 logger(DEBUG, "Finished reading in the filename.");
 
@@ -622,11 +622,11 @@ proc_includes (FILE *source_fd, FILE *dest_fd)
                   }
 
                 /// Open include file in read-only mode
-                sprintf (perror_msg, "include_fd = fopen('%s', 'r')",
+                sprintf (perror_msg, "include_fp = fopen('%s', 'r')",
                          filename_buffer);
                 logger(DEBUG, perror_msg);
-                FILE *include_fd = fopen (filename_buffer, "r");
-                if (include_fd != NULL)
+                FILE *include_fp = fopen (filename_buffer, "r");
+                if (include_fp != NULL)
                   _PASS;
                 else
                   {
@@ -635,22 +635,22 @@ proc_includes (FILE *source_fd, FILE *dest_fd)
                     return (errno);
                   }
 
-                char ch_2 = fgetc (include_fd);
+                char ch_2 = fgetc (include_fp);
 
                 /// Move contents of include file into destination file
                 logger(DEBUG, "Copy contents of %s into destination file",
                        filename_buffer);
                 while (ch_2 != EOF)
                   {
-                    fputc (ch_2, dest_fd);
-                    ch_2 = fgetc (include_fd);
+                    fputc (ch_2, dest_fp);
+                    ch_2 = fgetc (include_fp);
                   }
                 _DONE;
 
                 /// Flush destination file contents to disk
-                sprintf (perror_msg, "fflush(dest_fd)");
+                sprintf (perror_msg, "fflush(dest_fp)");
                 logger(DEBUG, perror_msg);
-                if (fflush (dest_fd) == EXIT_SUCCESS)
+                if (fflush (dest_fp) == EXIT_SUCCESS)
                   _PASS;
                 else
                   {
@@ -659,10 +659,10 @@ proc_includes (FILE *source_fd, FILE *dest_fd)
                     return (errno);
                   }
 
-                /// Close include file descriptor
-                sprintf (perror_msg, "fclose (include_fd)");
+                /// Close include file pointer
+                sprintf (perror_msg, "fclose (include_fp)");
                 logger(DEBUG, perror_msg);
-                if (fclose (include_fd) == EXIT_SUCCESS)
+                if (fclose (include_fp) == EXIT_SUCCESS)
                   _PASS;
                 else
                   {
@@ -675,11 +675,11 @@ proc_includes (FILE *source_fd, FILE *dest_fd)
           }
         default:
           {
-            fputc (ch, dest_fd);
+            fputc (ch, dest_fp);
           }
         }
       /// Gets the next char for the switch case to evaluate.
-      ch = fgetc (source_fd);
+      ch = fgetc (source_fp);
     }
 
   logger(DEBUG, "=== END ===");
@@ -871,11 +871,11 @@ get_lexeme_str (lexeme_s lexeme, char *buffer)
 }
 
 /**
- * @brief       Populate symbol table with lexemes in source file descriptor
+ * @brief       Populate symbol table with lexemes in source file pointer
  *
  * @param[in/out]   symbol_table    Symbol table linked list to populate
  * @param[in/out]   symbol_count    Pointer to count of lexemes found
- * @param[in/out]   source_fd       Source file descriptor
+ * @param[in/out]   source_fp       Source file pointer
  *
  * @return      The error return code of the function.
  *
@@ -926,10 +926,10 @@ build_symbol_table (lexeme_s *symbol_table, int *symbol_count)
 }
 
 /**
- * @brief       Print symbol table to destination file descriptor
+ * @brief       Print symbol table to destination file pointer
  *
  * @param[in/out]   symbol_table    Symbol table to print
- * @param[in/out]   dest_fd         Destination file descriptor
+ * @param[in/out]   dest_fp         Destination file pointer
  *
  * @return      The error return code of the function.
  *
@@ -940,7 +940,7 @@ build_symbol_table (lexeme_s *symbol_table, int *symbol_count)
  */
 
 short
-print_symbol_table (lexeme_s *symbol_table, FILE *dest_fd)
+print_symbol_table (lexeme_s *symbol_table, FILE *dest_fp)
 {
   logger(DEBUG, "=== START ===");
 
@@ -949,9 +949,9 @@ print_symbol_table (lexeme_s *symbol_table, FILE *dest_fd)
   assert(symbol_table);
   _PASS;
 
-  /// Assert destination file descriptor is not NULL
-  logger(DEBUG, "assert(dest_fd)");
-  assert(dest_fd);
+  /// Assert destination file pointer is not NULL
+  logger(DEBUG, "assert(dest_fp)");
+  assert(dest_fp);
   _PASS;
 
   // TODO: Replace stub implementation next


### PR DESCRIPTION
Run log with changes
```
kdamle@kedar-ThinkPad-X390:~/CS467/OPaL$ make all_tests 
# Delete binaries
rm -fv build/* output/* tmp/*
removed 'build/alex'
removed 'build/libopal.so'
removed 'build/marc'
removed 'build/opal.o'
removed 'build/opal.tar'
removed 'output/test1.opl'
removed 'output/test2.opl'
removed 'output/test3.opl'
removed 'output/test4.opl'
removed 'output/test5.opl'
removed 'output/test6.opl'
removed 'tmp/marc_pi.tmp'
removed 'tmp/marc_rc.tmp'
mkdir -pv build tmp log report doc output
gcc -g -O0 -fPIC -c -Wall src/opal.c -o build/opal.o
ld -shared build/opal.o -o build/libopal.so
gcc -g -O0 -Wall -L./build -Wl,-rpath=./ src/marc.c -g -lopal -o build/marc
gcc -g -O0 -Wall -L./build -Wl,-rpath=./ src/alex.c -g -lopal -o build/alex
tar -cvf build/opal.tar build/libopal.so build/opal.o build/marc build/alex
build/libopal.so
build/opal.o
build/marc
build/alex

=== Test 1 ===
build/marc --debug --output=output/test1.opl input/test1.opl
diff -s output/test1.opl test/test1.opl
Files output/test1.opl and test/test1.opl are identical

=== Test 2 ===
build/marc --debug --output=output/test2.opl input/test2.opl
diff -s output/test2.opl test/test2.opl
Files output/test2.opl and test/test2.opl are identical

=== Test 3 ===
build/marc --debug --output=output/test3.opl input/test3.opl
diff -s output/test3.opl test/test3.opl
Files output/test3.opl and test/test3.opl are identical

=== Test 4 ===
build/marc --debug --output=output/test4.opl input/test4.opl
diff -s output/test4.opl test/test4.opl
Files output/test4.opl and test/test4.opl are identical

=== Test 5 ===
build/marc --debug --output=output/test5.opl input/test5.opl
diff -s output/test5.opl test/test5.opl
Files output/test5.opl and test/test5.opl are identical

=== Test 6 ===
build/marc --debug --output=output/test6.opl input/test6.opl
diff -s output/test6.opl test/test6.opl
Files output/test6.opl and test/test6.opl are identical

=== Test 7 ===
build/marc --debug input/test7.opl
access('_DOES_NOT_EXIST_.hpl', F_OK): No such file or directory

=== Test 8 ===
build/marc --debug input/test8.opl
access('input/_RESTRICTED_.hpl', R_OK): Permission denied

=== Test 9 ===
build/marc
Usage: marc [OPTION...] FILE
Try `marc --help' or `marc --usage' for more information.

=== Test 10 ===
build/marc --debug --output=test.tmp
Usage: marc [OPTION...] FILE
Try `marc --help' or `marc --usage' for more information.

=== Test 11 ===
build/marc --invalid_flag --output=test.tmp
build/marc: unrecognized option '--invalid_flag'
Try `marc --help' or `marc --usage' for more information.

=== Test 12 ===
CLI test for valid case: 2 arguments & 1 valid flag provided.

=== Test 13 ===
build/marc --invalid_flag --output=test.tmp input/test2.opl
build/marc: unrecognized option '--invalid_flag'
Try `marc --help' or `marc --usage' for more information.

=== Test 14 ===
build/marc --debug --output=test.tmp input/test2.opl invalid_argument
Usage: marc [OPTION...] FILE
Try `marc --help' or `marc --usage' for more information.

=== Test 15 ===
build/marc --invalid_flag --output=test.tmp input/test2.opl invalid_argument
build/marc: unrecognized option '--invalid_flag'
Try `marc --help' or `marc --usage' for more information.
```