### PR TITLE
Fixing issue 37 - alex - ident string empty

### DIFF
--- a/src/opal.c
+++ b/src/opal.c
@@ -1150,7 +1150,7 @@ build_symbol_table (lexeme_s *symbol_table, int *symbol_count)
       new_symbol->int_val = next_lexeme.int_val;
 
       new_symbol->char_val =
-          next_lexeme.char_val ? next_lexeme.char_val : NULL;
+          next_lexeme.char_val ? strdup(next_lexeme.char_val) : NULL;
 
       /// Call get_lexeme_str() to stringify next_lexeme
       if (get_lexeme_str (new_symbol, lexeme_str,


### PR DESCRIPTION
Fix: build_symbol_table () uses strdup() to get the identifier char_val instead of just assigning the transient pointer from local struct
Root cause: Developer oversight.

```
$ cat input/test16.opl
// Test for parsing valid identifier lexemes
 
alpha = 1;
 
alpha2 = 2;
 
alpha_beta = alpha + alpha2;
$ export LD_LIBRARY_PATH=build/

$ build/alex --debug input/test16.opl
line:   0, column:   0, type:     No_operation, int_val:      0, char_val: ''
line:   2, column:   1, type:       Identifier, int_val:      0, char_val: 'alpha'
line:   2, column:   7, type:        Op_Assign, int_val:      0, char_val: ''
line:   2, column:   9, type:          Integer, int_val:      1, char_val: ''
line:   2, column:  10, type:        Semicolon, int_val:      0, char_val: ''
line:   4, column:   1, type:       Identifier, int_val:      0, char_val: 'alpha2'
line:   4, column:   8, type:        Op_Assign, int_val:      0, char_val: ''
line:   4, column:  10, type:          Integer, int_val:      2, char_val: ''
line:   4, column:  11, type:        Semicolon, int_val:      0, char_val: ''
line:   6, column:   1, type:       Identifier, int_val:      0, char_val: 'alpha_beta'
line:   6, column:  12, type:        Op_Assign, int_val:      0, char_val: ''
line:   6, column:  14, type:       Identifier, int_val:      0, char_val: 'alpha'
line:   6, column:  20, type:           Op_Add, int_val:      0, char_val: ''
line:   6, column:  22, type:       Identifier, int_val:      0, char_val: 'alpha2'
line:   6, column:  28, type:        Semicolon, int_val:      0, char_val: ''
```